### PR TITLE
Fixed dev path with deploy compatibility

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "client/bower_components"
+  "directory": "bower_components"
 }

--- a/app/index.html
+++ b/app/index.html
@@ -14,8 +14,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../bower_components/iron-component-page/iron-component-page.html">
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
 
 </head>
 <body unresolved>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -126,7 +126,7 @@ gulp.task('copy', function () {
     'app/*',
     '!app/test',
     '!app/elements',
-    '!client/bower_components',
+    '!bower_components',
     '!app/cache-config.json',
     '!**/.DS_Store'
   ], {
@@ -136,7 +136,7 @@ gulp.task('copy', function () {
   // Copy over only the bower_components we need
   // These are things which cannot be vulcanized
   var bower = gulp.src([
-    'client/bower_components/{webcomponentsjs,platinum-sw,sw-toolbox,promise-polyfill}/**/*'
+    'bower_components/{webcomponentsjs,platinum-sw,sw-toolbox,promise-polyfill}/**/*'
   ]).pipe(gulp.dest(dist('bower_components')));
 
   return merge(app, bower)
@@ -163,7 +163,7 @@ gulp.task('html', function () {
 
 // Transpile all JS to ES5.
 gulp.task('js', function () {
-  return gulp.src(['app/**/*.{js,html}', '!client/bower_components/**/*'])
+  return gulp.src(['app/**/*.{js,html}', '!bower_components/**/*'])
     .pipe($.sourcemaps.init())
     .pipe($.if('*.html', $.crisper({scriptInHead: false}))) // Extract JS from .html files
     .pipe($.if('*.js', $.babel({
@@ -203,7 +203,7 @@ gulp.task('cache-config', function (callback) {
   glob([
       'index.html',
       './',
-      'client/bower_components/webcomponentsjs/webcomponents-lite.min.js',
+      'bower_components/webcomponentsjs/webcomponents-lite.min.js',
       '{elements,scripts,styles}/**/*.*'],
     {cwd: dir}, function (error, files) {
       if (error) {
@@ -245,7 +245,7 @@ gulp.task('serve', ['styles', 'elements', 'images', 'js'], function () {
     //       will present a certificate warning in the browser.
     // https: true,
     server: {
-      baseDir: ['.tmp', 'app', 'client'],
+      baseDir: ['.tmp', 'app', 'bower_components'],
       middleware: [historyApiFallback()]
     }
   });


### PR DESCRIPTION
This fixes #1 establishing the same ´bower_components´ path for ´gulp:serve´ and deploys.
